### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md --allow-dupe --allow-redirect

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ _Note: for an OS specific tool, please do your best to mark with `OSX/WIN/*NIX/L
 * [Emmet](https://github.com/sergeche/emmet-sublime)
 * [Git Gutter](https://github.com/jisaacks/GitGutter) - display changed/added lines in the margin of the editor window.
 * [jsFormat](https://github.com/jdc0589/JsFormat) - Javascript formatting.
-* [LiveReload](https://github.com/dz0ny/LiveReload-sublimetext2) - LiveReload plugin.
+* [LiveReload](https://github.com/Grafikart/ST3-LiveReload) - LiveReload plugin for Sublime Text 3.
 * [MarkdownEditing](https://github.com/SublimeText-Markdown/MarkdownEditing) - Markdown syntax understanding and good color schemes.
 * [Package Control](https://sublime.wbond.net/installation) - The Sublime Text package manager.
 * [RubyTest](https://github.com/maltize/sublime-text-2-ruby-tests) - Plugin for running Ruby tests.


### PR DESCRIPTION
* Added a travis configuration to check links in README.md
* dz0ny/LiveReload-sublimetext2 has gone 404, replaced it with Grafikart/ST3-LiveReload

You'll have to enable it on travis-ci.org, but it runs on my fork and found the bad LiveReload link