### PR TITLE
Add Bidbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ _Note: for an OS specific tool, please do your best to mark with `OSX/WIN/*NIX/L
 *Tools for improving and hacking around with your vanilla desktop*
 
 * [Alfred](http://www.alfredapp.com/) - OSX productivity app `/OSX/`
+* [Bidbar](https://www.getbidbar.com/) - Manage bash commands from the menu bar `/OSX/`
 * [hydra](https://github.com/sdegutis/hydra) - script your desktop
   `/OSX/`
 * [Keycastr](https://github.com/sdeken/keycastr) - show your keys while


### PR DESCRIPTION
Bidbar is a macOS app that allows you to manage bash commands from the menu bar. 