### PR TITLE
New "Documentation" category, and add Log4brains to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ _Note: for an OS specific tool, please do your best to mark with `OSX/WIN/*NIX/L
 - [Data](#data)
 - [Diagnostics](#diagnostics)
 - [Desktop](#desktop)
+- [Documentation](#documentation)
 - [Dotfiles](#dotfiles)
 - [Editors](#editors)
   - [Atom](#atom)
@@ -89,6 +90,11 @@ _Note: for an OS specific tool, please do your best to mark with `OSX/WIN/*NIX/L
   `/OSX/`
 * [Keycastr](https://github.com/sdeken/keycastr) - show your keys while
   presenting/casting `/OSX/`
+
+## Documentation
+*Tools to document your project*
+
+* [Log4brains](https://github.com/thomvaill/log4brains) - Docs-as-code knowledge base to manage Architecture Decision Records (ADR) for your project and publish them automatically as a static website.
 
 
 ## Dotfiles


### PR DESCRIPTION
Repo: https://github.com/thomvaill/log4brains

> Log4brains is a docs-as-code knowledge base for your development and infrastructure projects. It enables you to write and manage Architecture Decision Records (ADR) right from your IDE, and to publish them automatically as a static website.

I released this new project a few days ago, and I hope you will find it interesting enough to add it to your awesome list!
I am also looking for beta testers and any feedback will be very welcome! 🙏

Thanks!