### PR TITLE
Add taskctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,4 @@ to `/home/Users/yourself/projects`.
 * [ergo](https://github.com/cristianoliveira/ergo) - The management of multiple local services running over different ports made easy.
 * [Prodmodel](https://github.com/prodmodel/prodmodel) - Build tool for data science pipelines.
 * [Gebug](https://github.com/moshebe/gebug) - A tool that makes debugging of Dockerized Go applications super easy by enabling Debugger and Hot-Reload features, seamlessly.
+* [taskctl](https://github.com/taskctl/taskctl) - Concurrent task runner, developer's routine tasks automation toolkit


### PR DESCRIPTION
Add https://github.com/taskctl/taskctl

Taskctl is 

> Concurrent task runner, developer's routine tasks automation toolkit. Simple modern alternative to GNU Make