### PR TITLE
Add just in workflow section

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ to `/home/Users/yourself/projects`.
   will emit FS events and you can run commands on demand with. Note -
 `fswatch-run` too.
 * [guard](https://github.com/guard/guard) - FS watch tool with a huge ecosystem of plugins
+* [just](https://github/casey/just) - A task runner for conveniently saving and running project-specific commands. Similar to make, but much nicer
 * [LiveReload](http://livereload.com/) - FS watch and preprocessor as a desktop app for `/OSX/` and `/WIN/` with complementary browser extensions
   * [guard-livereload](https://github.com/guard/guard-livereload) - Guard plugin compatible with LiveReload's browser extensions
   * [simplehttp](https://github.com/snwfdhmp/simplehttp) Fastest and simplest way to start serving a local directory over http.


### PR DESCRIPTION
Adds a tool I maintain, `just` to the workflow section. It's similar to make, in that it lets you save commands to a file to run later, but it's much nicer. It's actively maintained, and although it hasn't hit 1.0, it's extremely stable.