### PR TITLE
Add Meta Package Manager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ to `/home/Users/yourself/projects`.
 * [httpie](http://httpie.org/) A command line HTTP client, a user-friendly cURL replacement.
 * [iTerm2](http://www.iterm2.com/) - a great terminal replacement `/OSX/`
 * [jq](https://stedolan.github.io/jq/) - a lightweight and flexible command-line JSON processor
+* [mpm](https://github.com/kdeldycke/meta-package-manager) - meta package manager, a wrapper around all package managers.
 * [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) - the
   incredible ZSH addon.
 * [Pipe Viewer](http://www.ivarch.com/programs/pv.shtml) - a tool for monitoring the progress of data through a pipeline


### PR DESCRIPTION
Meta Package Manager provides the `mpm` CLI, a wrapper around all package managers.

Features:

- Inventory and list all package managers available on the system.
- Supports macOS, Linux and Windows.
- List installed packages.
- Search for packages.
- Install a package.
- Remove a package.
- List outdated packages.
- Sync local package infos.
- Upgrade all outdated packages.
- Backup list of installed packages to TOML file.
- Restore/install list of packages from TOML files.
- Pin-point commands to a subset of package managers (include/exclude selectors).
- Support plain, versionned and [purl](https://github.com/package-url/purl-spec) package specifiers.
- Export output to JSON or print user-friendly tables.
- Shell auto-completion for Bash, Zsh and Fish.
