### PR TITLE
Add Havoptic to Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ _Note: for an OS specific tool, please do your best to mark with `OSX/WIN/*NIX/L
 *Useful tools that cannot find a home in other categories*
 
 * [Fenix Web Server](https://fenixwebserver.com) - A multi-host local static web server with push-button sharing (desktop app).
+* [Havoptic](https://havoptic.com) - A timeline tracking releases from AI coding tools like Claude Code, Cursor, Gemini CLI, and more.
 * [ML Workspace](hhttps://github.com/ml-tooling/ml-workspace) - All-in-one web-based development environment for machine learning and data science.
 * [Mockoon](https://mockoon.com) - an API / HTTP REST mocking desktop application
 * [HTTP Toolkit](https://httptoolkit.tech) - an HTTP inspection & debugging desktop application


### PR DESCRIPTION
## Add Havoptic

Adding Havoptic to the Misc section (alphabetically sorted).

**Website:** https://havoptic.com  
**Repository:** https://github.com/scotthavird/havoptic.com  
**License:** MIT

**Description:** A free, open-source timeline that tracks releases from AI coding tools (Claude Code, Cursor, Gemini CLI, Kiro, GitHub Copilot CLI, Windsurf). Auto-updated daily via GitHub Actions.

**Why it fits this list:** Helps developers stay updated on new releases from AI dev tools - useful for discovering what's new across the AI coding ecosystem.